### PR TITLE
Mask version number in config tests

### DIFF
--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -22,6 +22,15 @@
     "trace.file",
     "params.date"
   ],
+  "version_fields": [
+    "manifest.version",
+    "params.log_output_dir",
+    "params.output_dir_base",
+    "params.workflow_output_dir",
+    "report.file",
+    "timeline.file",
+    "trace.file"
+  ],
   "expected_result": {
     "docker": {
       "all_group_ids": "$(for i in `id --real --groups`; do echo -n \"--group-add=$i \"; done)",
@@ -33,7 +42,7 @@
       "author": "Nicole Zeltser",
       "description": "Nextflow pipeline for calculating read-depth related statistics for targeted sequencing experiments",
       "name": "calculate-targeted-coverage",
-      "version": "1.1.0"
+      "version": "VER.SI.ON"
     },
     "params": {
       "bait_bed": "",
@@ -56,7 +65,7 @@
       "input": {
         "bam": "/hot/resource/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam"
       },
-      "log_output_dir": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-1.1.0/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-1.1.0-19970704T165655Z",
+      "log_output_dir": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-VER.SI.ON-19970704T165655Z",
       "max_cpus": "16",
       "max_memory": "31 GB",
       "merge_operation": "collapse",
@@ -69,7 +78,7 @@
       "off_target_depth": true,
       "off_target_slop": "500",
       "output_dir": "/tmp/nf-config-test-outputs",
-      "output_dir_base": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-1.1.0/TWGSAMIN000001-T002-S02-F",
+      "output_dir_base": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F",
       "output_enriched_target_file": true,
       "patient": "null",
       "picard_CollectHsMetrics_extra_args": "",
@@ -90,7 +99,7 @@
       "target_interval_list": "",
       "ucla_cds": true,
       "work_dir": "/scratch/4674821",
-      "workflow_output_dir": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-1.1.0/TWGSAMIN000001-T002-S02-F/SAMtools-1.16.1"
+      "workflow_output_dir": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F/SAMtools-1.16.1"
     },
     "process": {
       "cache": true,
@@ -197,15 +206,15 @@
     },
     "report": {
       "enabled": true,
-      "file": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-1.1.0/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-1.1.0-19970704T165655Z/nextflow-log/report.html"
+      "file": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-VER.SI.ON-19970704T165655Z/nextflow-log/report.html"
     },
     "timeline": {
       "enabled": true,
-      "file": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-1.1.0/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-1.1.0-19970704T165655Z/nextflow-log/timeline.html"
+      "file": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-VER.SI.ON-19970704T165655Z/nextflow-log/timeline.html"
     },
     "trace": {
       "enabled": true,
-      "file": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-1.1.0/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-1.1.0-19970704T165655Z/nextflow-log/trace.txt"
+      "file": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-VER.SI.ON-19970704T165655Z/nextflow-log/trace.txt"
     },
     "tz": "sun.util.calendar.ZoneInfo[id=\"UTC\",offset=0,dstSavings=0,useDaylight=false,transitions=0,lastRule=null]",
     "workDir": "/scratch/4674821"


### PR DESCRIPTION
# Description
This updates the Nextflow configuration regression tests to use the new feature from https://github.com/uclahs-cds/tool-Nextflow-action/pull/40 and mask the version numbers. This should ensure that we never need to "fix" the tests by updating the versions ever again.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)]-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline on at least one A-mini sample with `run_delly = true`, `run_manta = true`, `run_qc = true`. For `run_delly = true`, I have tested 'variant_type' set to `gSV`, `gCNV`, and both. The paths to the test config files and output directories are captured above in the Testing Results section.
