### PR TITLE
Update cluster reference paths

### DIFF
--- a/config/template.config
+++ b/config/template.config
@@ -13,9 +13,9 @@ params {
     blcds_registered_dataset = false // if you want the output to be registered
 
     // reference files
-    reference_dict = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
-    reference_dbSNP = '/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
-    genome_sizes = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
+    reference_dict = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
+    reference_dbSNP = '/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
+    genome_sizes = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
 
     // interval file inputs
     target_bed = 'path/to/target/bedfile' //required

--- a/test/configtest-F16.json
+++ b/test/configtest-F16.json
@@ -61,9 +61,9 @@
       "docker_image_samtools": "ghcr.io/uclahs-cds/samtools:1.16.1",
       "docker_image_validate": "ghcr.io/uclahs-cds/pipeval:4.0.0-rc.2",
       "gatk_command_mem_diff": "2 GB",
-      "genome_sizes": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
+      "genome_sizes": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai",
       "input": {
-        "bam": "/hot/resource/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam"
+        "bam": "/hot/data/unregistered/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam"
       },
       "log_output_dir": "/tmp/nf-config-test-outputs/calculate-targeted-coverage-VER.SI.ON/TWGSAMIN000001-T002-S02-F/log-calculate-targeted-coverage-VER.SI.ON-19970704T165655Z",
       "max_cpus": "16",
@@ -84,8 +84,8 @@
       "picard_CollectHsMetrics_extra_args": "",
       "picard_version": "3.0.0",
       "pipeval_version": "4.0.0-rc.2",
-      "reference_dbSNP": "/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz",
-      "reference_dict": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
+      "reference_dbSNP": "/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz",
+      "reference_dict": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict",
       "sample": "null",
       "sample_id": "TWGSAMIN000001-T002-S02-F",
       "samtools_depth_extra_args": "",

--- a/test/nftest.config
+++ b/test/nftest.config
@@ -13,9 +13,9 @@ params {
     blcds_registered_dataset = false // if you want the output to be registered
 
     // reference files
-    reference_dict = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
-    reference_dbSNP = '/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
-    genome_sizes = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
+    reference_dict = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict'
+    reference_dbSNP = '/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz'
+    genome_sizes = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai'
 
     // interval file inputs
     target_bed = '/hot/software/pipeline/pipeline-calculate-targeted-coverage/Nextflow/development/input/GRch38-small.bed' //required

--- a/test/single.yaml
+++ b/test/single.yaml
@@ -1,4 +1,4 @@
 ---
 sample_id: 'TWGSAMIN000001-T002-S02-F'
 input:
-  bam: /hot/resource/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam
+  bam: /hot/data/unregistered/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                                   |                    | Updated                                                                               |                    |
|----------------------------------------------------------------------------|--------------------|---------------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai`  | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta.fai` | :white_check_mark: |
| `/hot/resource/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam`          | :white_check_mark: | `/hot/data/unregistered/SMC-HET/tumours/A-mini/bams/n1/output/S2.T-n1.bam`            | :white_check_mark: |
| `/hot/ref/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz` | :white_check_mark: | `/hot/resource/database/dbSNP-155/thinned/GRCh38/dbSNP-155_thinned_hg38.vcf.gz`       | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict`       | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict`      | :white_check_mark: |